### PR TITLE
adjusts legend margin to match axes

### DIFF
--- a/src/Viz.js
+++ b/src/Viz.js
@@ -249,106 +249,110 @@ export default class Viz extends BaseClass {
       @private
   */
   _draw() {
-
     const that = this;
 
-    // based on the groupBy, determine the draw depth and current depth id
-    this._drawDepth = this._depth !== void 0 ? this._depth : this._groupBy.length - 1;
-    this._id = this._groupBy[this._drawDepth];
-    this._ids = (d, i) => this._groupBy
-      .map(g => !d || d.__d3plus__ && !d.data ? undefined : g(d.__d3plus__ ? d.data : d, d.__d3plus__ ? d.i : i))
-      .filter(g => g !== undefined && g !== null && g.constructor !== Array);
-
-    this._drawLabel = (d, i) => {
-      if (!d) return "";
-      while (d.__d3plus__ && d.data) {
-        d = d.data;
-        i = d.i;
-      }
-      if (this._label) return this._label(d, i);
-      const l = that._ids(d, i).slice(0, this._drawDepth + 1);
-      return l[l.length - 1];
-    };
-
-    // set the default timeFilter if it has not been specified
-    if (this._time && this._timeFilter === void 0 && this._data.length) {
-
-      const dates = this._data.map(this._time).map(date);
-      const d = this._data[0], i = 0;
-
-      if (this._discrete && `_${this._discrete}` in this && this[`_${this._discrete}`](d, i) === this._time(d, i)) {
-        this._timeFilter = () => true;
-      }
-      else {
-        const latestTime = +max(dates);
-        this._timeFilter = (d, i) => +date(this._time(d, i)) === latestTime;
-      }
-
+    if (this._redrawLegend) {
+      drawLegend.bind(this)(this._filteredData);
     }
+    else {
+      // based on the groupBy, determine the draw depth and current depth id
+      this._drawDepth = this._depth !== void 0 ? this._depth : this._groupBy.length - 1;
+      this._id = this._groupBy[this._drawDepth];
+      this._ids = (d, i) => this._groupBy
+        .map(g => !d || d.__d3plus__ && !d.data ? undefined : g(d.__d3plus__ ? d.data : d, d.__d3plus__ ? d.i : i))
+        .filter(g => g !== undefined && g !== null && g.constructor !== Array);
 
-    this._filteredData = [];
-    let flatData = [];
-    if (this._data.length) {
+      this._drawLabel = (d, i) => {
+        if (!d) return "";
+        while (d.__d3plus__ && d.data) {
+          d = d.data;
+          i = d.i;
+        }
+        if (this._label) return this._label(d, i);
+        const l = that._ids(d, i).slice(0, this._drawDepth + 1);
+        return l[l.length - 1];
+      };
 
-      flatData = this._timeFilter ? this._data.filter(this._timeFilter) : this._data;
-      if (this._filter) flatData = flatData.filter(this._filter);
+      // set the default timeFilter if it has not been specified
+      if (this._time && this._timeFilter === void 0 && this._data.length) {
 
-      const dataNest = nest();
-      for (let i = 0; i <= this._drawDepth; i++) dataNest.key(this._groupBy[i]);
-      if (this._discrete && `_${this._discrete}` in this) dataNest.key(this[`_${this._discrete}`]);
-      if (this._discrete && `_${this._discrete}2` in this) dataNest.key(this[`_${this._discrete}2`]);
-      dataNest.rollup(leaves => this._filteredData.push(merge(leaves, this._aggs))).entries(flatData);
+        const dates = this._data.map(this._time).map(date);
+        const d = this._data[0], i = 0;
 
+        if (this._discrete && `_${this._discrete}` in this && this[`_${this._discrete}`](d, i) === this._time(d, i)) {
+          this._timeFilter = () => true;
+        }
+        else {
+          const latestTime = +max(dates);
+          this._timeFilter = (d, i) => +date(this._time(d, i)) === latestTime;
+        }
+
+      }
+
+      this._filteredData = [];
+      let flatData = [];
+      if (this._data.length) {
+
+        flatData = this._timeFilter ? this._data.filter(this._timeFilter) : this._data;
+        if (this._filter) flatData = flatData.filter(this._filter);
+
+        const dataNest = nest();
+        for (let i = 0; i <= this._drawDepth; i++) dataNest.key(this._groupBy[i]);
+        if (this._discrete && `_${this._discrete}` in this) dataNest.key(this[`_${this._discrete}`]);
+        if (this._discrete && `_${this._discrete}2` in this) dataNest.key(this[`_${this._discrete}2`]);
+        dataNest.rollup(leaves => this._filteredData.push(merge(leaves, this._aggs))).entries(flatData);
+
+      }
+      if (this._noDataMessage && !this._filteredData.length) {
+        this._messageClass.render({
+          container: this._select.node().parentNode,
+          html: this._noDataHTML(this),
+          mask: this._messageMask,
+          style: this._messageStyle
+        });
+      }
+
+      drawTitle.bind(this)(this._filteredData);
+      drawControls.bind(this)(this._filteredData);
+      drawTimeline.bind(this)(this._filteredData);
+      drawLegend.bind(this)(this._filteredData);
+      drawColorScale.bind(this)(this._filteredData);
+      drawBack.bind(this)();
+      drawTotal.bind(this)(this._filteredData);
+
+      this._shapes = [];
+
+      // Draws a container and zoomGroup to test functionality.
+      // this._container = this._select.selectAll("svg.d3plus-viz").data([0]);
+      //
+      // this._container = this._container.enter().append("svg")
+      //     .attr("class", "d3plus-viz")
+      //     .attr("width", this._width - this._margin.left - this._margin.right)
+      //     .attr("height", this._height - this._margin.top - this._margin.bottom)
+      //     .attr("x", this._margin.left)
+      //     .attr("y", this._margin.top)
+      //     .style("background-color", "transparent")
+      //   .merge(this._container);
+      //
+      // this._zoomGroup = this._container.selectAll("g.d3plus-viz-zoomGroup").data([0]);
+      // const enter = this._zoomGroup.enter().append("g").attr("class", "d3plus-viz-zoomGroup")
+      //   .merge(this._zoomGroup);
+      //
+      // this._zoomGroup = enter.merge(this._zoomGroup);
+      //
+      // this._shapes.push(new Rect()
+      //   .config(this._shapeConfig)
+      //   .data(this._filteredData)
+      //   .label("Test Label")
+      //   .select(this._zoomGroup.node())
+      //   .on(this._on)
+      //   .id(d => d.group)
+      //   .x(d => d.value * 10 + 200)
+      //   .y(d => d.value * 10 + 200)
+      //   .width(100)
+      //   .height(100)
+      //   .render());
     }
-    if (this._noDataMessage && !this._filteredData.length) {
-      this._messageClass.render({
-        container: this._select.node().parentNode,
-        html: this._noDataHTML(this),
-        mask: this._messageMask,
-        style: this._messageStyle
-      });
-    }
-
-    drawTitle.bind(this)(this._filteredData);
-    drawControls.bind(this)(this._filteredData);
-    drawTimeline.bind(this)(this._filteredData);
-    drawLegend.bind(this)(this._filteredData);
-    drawColorScale.bind(this)(this._filteredData);
-    drawBack.bind(this)();
-    drawTotal.bind(this)(this._filteredData);
-
-    this._shapes = [];
-
-    // Draws a container and zoomGroup to test functionality.
-    // this._container = this._select.selectAll("svg.d3plus-viz").data([0]);
-    //
-    // this._container = this._container.enter().append("svg")
-    //     .attr("class", "d3plus-viz")
-    //     .attr("width", this._width - this._margin.left - this._margin.right)
-    //     .attr("height", this._height - this._margin.top - this._margin.bottom)
-    //     .attr("x", this._margin.left)
-    //     .attr("y", this._margin.top)
-    //     .style("background-color", "transparent")
-    //   .merge(this._container);
-    //
-    // this._zoomGroup = this._container.selectAll("g.d3plus-viz-zoomGroup").data([0]);
-    // const enter = this._zoomGroup.enter().append("g").attr("class", "d3plus-viz-zoomGroup")
-    //   .merge(this._zoomGroup);
-    //
-    // this._zoomGroup = enter.merge(this._zoomGroup);
-    //
-    // this._shapes.push(new Rect()
-    //   .config(this._shapeConfig)
-    //   .data(this._filteredData)
-    //   .label("Test Label")
-    //   .select(this._zoomGroup.node())
-    //   .on(this._on)
-    //   .id(d => d.group)
-    //   .x(d => d.value * 10 + 200)
-    //   .y(d => d.value * 10 + 200)
-    //   .width(100)
-    //   .height(100)
-    //   .render());
 
   }
 
@@ -362,6 +366,7 @@ export default class Viz extends BaseClass {
 
     // Resets margins
     this._margin = {bottom: 0, left: 0, right: 0, top: 0};
+    this._legendMargin = {bottom: 0, left: 0, right: 0, top: 0};
     this._transition = transition().duration(this._duration);
 
     // Appends a fullscreen SVG to the BODY if a container has not been provided through .select().

--- a/src/_drawLegend.js
+++ b/src/_drawLegend.js
@@ -19,20 +19,26 @@ export function legendLabel(d, i) {
 */
 export default function(data = []) {
 
-  const transform = {transform: `translate(${this._margin.left}, ${this._margin.top})`};
-
-  const legendGroup = elem("g.d3plus-viz-legend", {
-    condition: this._legend && !this._legendConfig.select,
-    enter: transform,
-    parent: this._select,
-    transition: this._transition,
-    update: transform
-  }).node();
-
   if (this._legend) {
 
+    const legendBounds = this._legendClass.outerBounds();
     const position = this._legendPosition;
     const wide = ["top", "bottom"].includes(position);
+
+    if (this._redrawLegend && !this._legendConfig.select && legendBounds.height) {
+      if (wide) this._margin[position] -= legendBounds.height + this._legendClass.padding() * 2;
+      else this._margin[position] -= legendBounds.width + this._legendClass.padding() * 2;
+    }
+
+    const transform = {transform: `translate(${this._margin.left + wide ? this._legendMargin.left : 0}, ${this._margin.top + wide ? 0 : this._legendMargin.top})`};
+
+    const legendGroup = elem("g.d3plus-viz-legend", {
+      condition: this._legend && !this._legendConfig.select,
+      enter: transform,
+      parent: this._select,
+      transition: this._transition,
+      update: transform
+    }).node();
 
     const legendData = [];
 
@@ -57,28 +63,26 @@ export default function(data = []) {
       .key(fill)
       .rollup(leaves => legendData.push(merge(leaves, this._aggs)))
       .entries(this._colorScale ? data.filter((d, i) => this._colorScale(d, i) === undefined) : data);
-
+    
     this._legendClass
       .id(fill)
       .align(wide ? "center" : position)
       .direction(wide ? "row" : "column")
       .duration(this._duration)
       .data(legendData.length > 1 || this._colorScale ? legendData : [])
-      .height(this._height - this._margin.bottom - this._margin.top)
+      .height(wide ? this._height - (this._margin.bottom + this._margin.top) : this._height - (this._margin.bottom + this._margin.top + this._legendMargin.bottom + this._legendMargin.top))
       .select(legendGroup)
       .verticalAlign(!wide ? "middle" : position)
-      .width(this._width - this._margin.left - this._margin.right)
+      .width(wide ? this._width - (this._margin.left + this._margin.right + this._legendMargin.left + this._legendMargin.right) : this._width - (this._margin.left + this._margin.right))
       .shapeConfig(configPrep.bind(this)(this._shapeConfig, "legend"))
       .config(this._legendConfig)
       .shapeConfig({fill: color, opacity})
       .render();
 
-    const legendBounds = this._legendClass.outerBounds();
     if (!this._legendConfig.select && legendBounds.height) {
       if (wide) this._margin[position] += legendBounds.height + this._legendClass.padding() * 2;
       else this._margin[position] += legendBounds.width + this._legendClass.padding() * 2;
     }
-
   }
-
+  this._redrawLegend = false;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This PR goes with [this one in d3Plus-plot](https://github.com/d3plus/d3plus-plot/pull/84) and together they close [this issue](https://github.com/d3plus/d3plus-plot/issues/75).

### Description
<!--- Describe your changes in detail -->
Modifies the `_draw( )` function in `Viz` so that when `redrawLegend` is true, only the legend is drawn. Adds logic to `_drawLegend` to account for `legendMargins` and to account for adjustments to the `Viz` margins when the legend is redrawn.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

