### PR TITLE
fixes draw order so colorScale is only drawn once

### DIFF
--- a/src/Viz.js
+++ b/src/Viz.js
@@ -321,7 +321,7 @@ export default class Viz extends BaseClass {
     }
 
     if (this.legendPosition() === "left" || this.legendPosition() === "right") drawLegend.bind(this)(this._filteredData);
-    if (this.colorScalePosition() === "left" || this.legendPosition() === "right") drawColorScale.bind(this)(this._filteredData);
+    if (this.colorScalePosition() === "left" || this.colorScalePosition() === "right") drawColorScale.bind(this)(this._filteredData);
 
     drawBack.bind(this)();
     drawTitle.bind(this)(this._filteredData);
@@ -330,7 +330,7 @@ export default class Viz extends BaseClass {
     drawControls.bind(this)(this._filteredData);
 
     if (this.legendPosition() === "top" || this.legendPosition() === "bottom") drawLegend.bind(this)(this._filteredData);
-    if (this.colorScalePosition() === "top" || this.legendPosition() === "bottom") drawColorScale.bind(this)(this._filteredData);
+    if (this.colorScalePosition() === "top" || this.colorScalePosition() === "bottom") drawColorScale.bind(this)(this._filteredData);
 
     this._shapes = [];
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
(closes #71 )
### Description
<!--- Describe your changes in detail -->
I am a chump and totally caused this bug. Because of the incorrect use of `this.legendPosition()` instead of `this.colorScalePosition()` [here](https://github.com/d3plus/d3plus-viz/blob/master/src/Viz.js#L324) and [here](https://github.com/d3plus/d3plus-viz/blob/master/src/Viz.js#L333) in the `_draw( )` function, `drawColorScale` was being called twice. `drawColorScale` modifies the margin of the viz to account for the space that the color scale will take up. Because the color scale was being drawn twice the margin was incorrectly affecting its positioning the second time `drawColorScale` was being called.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

