### PR TITLE
creates click.all event that hides the tooltip

### DIFF
--- a/src/Viz.js
+++ b/src/Viz.js
@@ -37,6 +37,7 @@ import inViewport from "./_inViewport";
 import load from "./data/load";
 
 import click from "./on/click";
+import clickAll from "./on/click.all";
 import mouseenter from "./on/mouseenter";
 import mouseleave from "./on/mouseleave";
 import mousemoveLegend from "./on/mousemove.legend";
@@ -135,6 +136,7 @@ export default class Viz extends BaseClass {
     this._noDataMessage = true;
     this._on = {
       "click": click.bind(this),
+      "click.all": clickAll.bind(this),
       "mouseenter": mouseenter.bind(this),
       "mouseleave": mouseleave.bind(this),
       "mousemove.shape": mousemoveShape.bind(this),

--- a/src/on/click.all.js
+++ b/src/on/click.all.js
@@ -1,0 +1,7 @@
+/**
+ @desc Global on click event for all entities in a Viz.
+ @private
+ */
+export default function() {
+  if (this._tooltip) this._tooltipClass.data([]).render();
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
(closes #69)

### Description
<!--- Describe your changes in detail -->
Creates a default `click.all` event which is passed to all shapes in a Viz and hides the tooltip.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

