### PR TITLE
moves noDataMessage logic from _draw to _predraw

### DIFF
--- a/src/Viz.js
+++ b/src/Viz.js
@@ -305,14 +305,7 @@ export default class Viz extends BaseClass {
       dataNest.rollup(leaves => this._filteredData.push(merge(leaves, this._aggs))).entries(flatData);
 
     }
-  }
 
-  /**
-      @memberof Viz
-      @desc Called by render once all checks are passed.
-      @private
-  */
-  _draw() {
     if (this._noDataMessage && !this._filteredData.length) {
       this._messageClass.render({
         container: this._select.node().parentNode,
@@ -322,6 +315,14 @@ export default class Viz extends BaseClass {
       });
     }
 
+  }
+
+  /**
+      @memberof Viz
+      @desc Called by render once all checks are passed.
+      @private
+  */
+  _draw() {
     if (this.legendPosition() === "left" || this.legendPosition() === "right") drawLegend.bind(this)(this._filteredData);
     if (this.colorScalePosition() === "left" || this.colorScalePosition() === "right") drawColorScale.bind(this)(this._filteredData);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
(closes #80 )

### Description
<!--- Describe your changes in detail -->
The bug was caused by the introduction of the `_preDraw` method. When no data is passed to a viz, the `_preDraw` method is called, but the `_draw` method is not called. Because the logic to display the "No Data Message" was inside the `_draw` method, the message was never displayed. 

To fix this bug, I moved the logic to display the "No Data Message" from inside the `_draw` method to inside the `preDraw` method.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

