### PR TITLE
fixes bug when re-render the visualization

### DIFF
--- a/src/Viz.js
+++ b/src/Viz.js
@@ -1048,6 +1048,7 @@ function value(d) {
           };
         }
       }
+      this._timeFilter = false;
       return this;
     }
     else return this._time;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
closes d3plus/d3plus-geomap#25

### Description
<!--- Describe your changes in detail -->
This bug was caused because the `lastYear` calculated in the first render was persistent in the next render. 

For to solve it, I set `this._timeFilter = false` when we use `time` in d3plus.

Also, fixes the problem in Vizbuilder related with charts that didn't  load correctly [https://github.com/Datawheel/canon/issues/170](https://github.com/Datawheel/canon/issues/170)
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

