### PR TITLE
fixes weird legend behavior

### DIFF
--- a/src/Viz.js
+++ b/src/Viz.js
@@ -275,7 +275,7 @@ export default class Viz extends BaseClass {
       .map(g => !d || d.__d3plus__ && !d.data ? undefined : g(d.__d3plus__ ? d.data : d, d.__d3plus__ ? d.i : i))
       .filter(g => g !== undefined && g !== null && g.constructor !== Array);
 
-    this._drawLabel = (d, i) => {
+    this._drawLabel = (d, i, legend = false) => {
       if (!d) return "";
       while (d.__d3plus__ && d.data) {
         d = d.data;
@@ -283,7 +283,7 @@ export default class Viz extends BaseClass {
       }
       if (this._label) return this._label(d, i);
       const l = that._ids(d, i).slice(0, this._drawDepth + 1);
-      return l[l.length - 1];
+      return legend ? l[0] : l[l.length - 1];
     };
 
     // set the default timeFilter if it has not been specified

--- a/src/Viz.js
+++ b/src/Viz.js
@@ -283,7 +283,7 @@ export default class Viz extends BaseClass {
       }
       if (this._label) return this._label(d, i);
       const l = that._ids(d, i).slice(0, this._drawDepth + 1);
-      return legend ? l[0] : l[l.length - 1];
+      return legend ? l[this._depth ? l.length - 1 : 0] : l[l.length - 1];
     };
 
     // set the default timeFilter if it has not been specified

--- a/src/_drawLegend.js
+++ b/src/_drawLegend.js
@@ -7,7 +7,7 @@ import {configPrep, elem, merge} from "d3plus-common";
     @private
 */
 export function legendLabel(d, i) {
-  const l = this._drawLabel(d, i);
+  const l = this._drawLabel(d, i, true);
   return l instanceof Array ? l.join(", ") : l;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
closes #103 

### Description
<!--- Describe your changes in detail -->
This bug was caused inside `_drawLabel` function of Viz.js, because that function always returns the last element. 

For to solve it, I added a flag for to return the first value in the legend.
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

