### PR TITLE
implements legend cutoff property and method

### DIFF
--- a/src/Viz.js
+++ b/src/Viz.js
@@ -129,6 +129,7 @@ export default class Viz extends BaseClass {
         }
       }
     };
+    this._legendCutoff = 1;
     this._legendPadding = defaultPadding;
     this._legendPosition = "bottom";
     this._legendTooltip = {};
@@ -1049,6 +1050,16 @@ function value(d) {
   */
   legendConfig(_) {
     return arguments.length ? (this._legendConfig = assign(this._legendConfig, _), this) : this._legendConfig;
+  }
+
+  /**
+   * @memberof Viz
+   * @desc If *value* is specified, sets the cutoff for the amount of categories in the legend.
+   * @param {number} [*value*]
+   * @chainable
+   */
+  legendCutoff(_) {
+    return arguments.length ? (this._legendCutoff = _, this) : this._legendCutoff;
   }
 
   /**

--- a/src/_drawLegend.js
+++ b/src/_drawLegend.js
@@ -71,7 +71,7 @@ export default function(data = []) {
       .align(wide ? "center" : position)
       .direction(wide ? "row" : "column")
       .duration(this._duration)
-      .data(legendData.length > 1 || this._colorScale ? legendData : [])
+      .data(legendData.length > this._legendCutoff || this._colorScale ? legendData : [])
       .height(wide ? this._height - (this._margin.bottom + this._margin.top) : this._height - (this._margin.bottom + this._margin.top + padding.bottom + padding.top))
       .select(legendGroup)
       .verticalAlign(!wide ? "middle" : position)


### PR DESCRIPTION
Implements a way to force d3plus to only show the legend if a set amount of categories are available.

### Description
Adds a new property to the Viz class called `Viz.prototype._legendCutoff`, with a default value of `1`. When rendering a legend, the code checks if the amount of categories is higher than this value, if it does it renders the legend, otherwise it doesn't. Also adds a method `Viz.prototype.legendCutoff` to change this value.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

