### PR TITLE
 pass down internal locale method in favor of BaseClass

### DIFF
--- a/src/Viz.js
+++ b/src/Viz.js
@@ -155,7 +155,6 @@ export default class Viz extends BaseClass {
     </div>`);
 
     this._loadingMessage = true;
-    this._locale = "en-US";
     this._lrucache = lrucache(10);
     this._messageClass = new Message();
     this._messageMask = "rgba(0, 0, 0, 0.1)";
@@ -1135,16 +1134,6 @@ function value(d) {
   */
   loadingMessage(_) {
     return arguments.length ? (this._loadingMessage = _, this) : this._loadingMessage;
-  }
-
-  /**
-      @memberof Viz
-      @desc If *value* is specified, sets the locale to the specified string and returns the current class instance.
-      @param {String} [*value* = "en-US"]
-      @chainable
-  */
-  locale(_) {
-    return arguments.length ? (this._locale = _, this) : this._locale;
   }
 
   /**

--- a/src/Viz.js
+++ b/src/Viz.js
@@ -323,7 +323,7 @@ export default class Viz extends BaseClass {
     this._drawLabel = (d, i) => {
       if (!d) return "";
       if (d._isAggregation) {
-        return `${this._thresholdName} < ${formatAbbreviate(d._threshold * 100)}%`;
+        return `${this._thresholdName} < ${formatAbbreviate(d._threshold * 100, this._locale)}%`;
       }
       while (d.__d3plus__ && d.data) {
         d = d.data;

--- a/src/_drawColorScale.js
+++ b/src/_drawColorScale.js
@@ -52,6 +52,7 @@ export default function() {
       .duration(this._duration)
       .data(scaleData)
       .height(height)
+      .locale(this._locale)
       .orient(position)
       .select(scaleGroup)
       .value(this._colorScale)

--- a/src/_drawLegend.js
+++ b/src/_drawLegend.js
@@ -75,6 +75,7 @@ export default function(data = []) {
       .duration(this._duration)
       .data(legendData.length > this._legendCutoff || this._colorScale ? legendData : [])
       .height(wide ? this._height - (this._margin.bottom + this._margin.top) : this._height - (this._margin.bottom + this._margin.top + padding.bottom + padding.top))
+      .locale(this._locale)
       .select(legendGroup)
       .verticalAlign(!wide ? "middle" : position)
       .width(wide ? this._width - (this._margin.left + this._margin.right + padding.left + padding.right) : this._width - (this._margin.left + this._margin.right))

--- a/src/_drawTimeline.js
+++ b/src/_drawTimeline.js
@@ -50,6 +50,7 @@ export default function(data = []) {
       .domain(extent(ticks))
       .duration(this._duration)
       .height(this._height - this._margin.bottom)
+      .locale(this._locale)
       .select(timelineGroup)
       .ticks(ticks.sort((a, b) => +a - +b))
       .width(this._width - (this._margin.left + this._margin.right + padding.left + padding.right));

--- a/src/_drawTitle.js
+++ b/src/_drawTitle.js
@@ -22,6 +22,7 @@ export default function(data = []) {
 
   this._titleClass
     .data(text ? [{text}] : [])
+    .locale(this._locale)
     .select(group)
     .width(this._width - (this._margin.left + this._margin.right + padding.left + padding.right))
     .config(this._titleConfig)

--- a/src/_drawTotal.js
+++ b/src/_drawTotal.js
@@ -28,6 +28,7 @@ export default function(data = []) {
 
   this._totalClass
     .data(visible ? [{text: this._totalFormat(total)}] : [])
+    .locale(this._locale)
     .select(group)
     .width(this._width - (this._margin.left + this._margin.right + padding.left + padding.right))
     .config(this._totalConfig)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
closes #75

This PR pass down internal locale method in favor of BaseClass, and include `this._locale` method in `formatAbbreviate` function.

### Description
<!--- Describe your changes in detail -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

