### PR TITLE
removes default behavior on colorScalePosition

### DIFF
--- a/src/Viz.js
+++ b/src/Viz.js
@@ -425,8 +425,10 @@ export default class Viz extends BaseClass {
   */
   _draw() {
 
-    const legendPosition = this._legendPosition.bind(this)(this.config());
-    const colorScalePosition = this._colorScalePosition.bind(this)(this.config());
+    let legendPosition = this._legendPosition.bind(this)(this.config());
+    if (![false, "top", "bottom", "left", "right"].includes(legendPosition)) legendPosition = "bottom";
+    let colorScalePosition = this._colorScalePosition.bind(this)(this.config());
+    if (![false, "top", "bottom", "left", "right"].includes(colorScalePosition)) colorScalePosition = "bottom";
     if (legendPosition === "left" || legendPosition === "right") drawLegend.bind(this)(this._legendData);
     if (colorScalePosition === "left" || colorScalePosition === "right" || colorScalePosition === false) drawColorScale.bind(this)(this._filteredData);
 

--- a/src/_drawColorScale.js
+++ b/src/_drawColorScale.js
@@ -10,7 +10,7 @@ export default function() {
 
   const data = this._data;
 
-  const position = this._colorScalePosition.bind(this)(this.config()) || "bottom";
+  const position = this._colorScalePosition.bind(this)(this.config());
   const wide = ["top", "bottom"].includes(position);
   const padding = this._colorScalePadding() ? this._padding : {top: 0, right: 0, bottom: 0, left: 0};
 

--- a/src/_drawColorScale.js
+++ b/src/_drawColorScale.js
@@ -10,7 +10,8 @@ export default function() {
 
   const data = this._data;
 
-  const position = this._colorScalePosition.bind(this)(this.config());
+  let position = this._colorScalePosition.bind(this)(this.config());
+  if (![false, "top", "bottom", "left", "right"].includes(position)) position = "bottom";
   const wide = ["top", "bottom"].includes(position);
   const padding = this._colorScalePadding() ? this._padding : {top: 0, right: 0, bottom: 0, left: 0};
 

--- a/src/_drawLegend.js
+++ b/src/_drawLegend.js
@@ -60,7 +60,8 @@ export default function(data = []) {
 
   const legendBounds = this._legendClass.outerBounds();
   const config = this.config();
-  const position = this._legendPosition.bind(this)(config);
+  let position = this._legendPosition.bind(this)(config);
+  if (![false, "top", "bottom", "left", "right"].includes(position)) position = "bottom";
   const wide = ["top", "bottom"].includes(position);
   const padding = this._legendPadding() ? this._padding : {top: 0, right: 0, bottom: 0, left: 0};
   const transform = {transform: `translate(${wide ? this._margin.left + padding.left : this._margin.left}, ${wide ? this._margin.top : this._margin.top + padding.top})`};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This PR adds a minor fix that solves the uncatched false value in color scale position logic, related to issue #153.

### Description
Checking the logic of color scale positioning function in this [line](https://github.com/d3plus/d3plus-viz/blob/master/src/_drawColorScale.js#L13) I realized that `|| "bottom"` condition applies if `colorScalePosition = false` is set on viz config, so user will always get a scale on bottom (or right) even when they set a false value.
To solve this issue, i removed the `|| "bottom"` option to keep the value defined by user.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

