### PR TITLE
solves preventDefault error on mobile resolutions

### DIFF
--- a/src/on/click.shape.js
+++ b/src/on/click.shape.js
@@ -4,7 +4,8 @@
     @param {Number} *i* The index of the data object being interacted with.
     @private
 */
-export default function(d, i) {
+export default function(d, i, x, event) {
+  event.stopPropagation();
 
   this._select.style("cursor", "auto");
 

--- a/src/on/touchstart.body.js
+++ b/src/on/touchstart.body.js
@@ -2,9 +2,6 @@
  @desc On touchstart event for the Body element.
  @private
  */
-export default function(d, i, x, event) {
-  event.preventDefault();
-  event.stopPropagation();
-
-  if (!d) this._tooltipClass.data([]).render();
+export default function() {
+  this._tooltipClass.data([]).render();
 }


### PR DESCRIPTION
### Description
This PR resolves the preventDefault console error that appears with any touch event on mobile resolutions, especially in Chrome, as reported by @palamago in #164.
To solve this, we removed the preventDefault and stopPropagation methods from the `on.touchstart.body` function turning it into a function that only removes the tooltip when the user touches the body outside of a d3plus svg element. Also, we included a stopPropagation method in the `on.click.shape` function to prevent event propagation when the user clicks on a d3plus shape.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

