### PR TITLE
coerces groupBy aggs to String for multi-point hover events

### DIFF
--- a/src/Viz.js
+++ b/src/Viz.js
@@ -1004,7 +1004,7 @@ function value(d) {
       else {
         if (!this._aggs[k]) {
           this._aggs[k] = (a, c) => {
-            const v = unique(a.map(c));
+            const v = unique(a.map(c).map(String));
             return v.length === 1 ? v[0] : v;
           };
         }


### PR DESCRIPTION
This PR fixes an issue where LinePlot hover events would not show the highlight styles for the Line if the Line's ID is numeric, as seen in [this JSFiddle](https://jsfiddle.net/4ovjhqxe/) by @AlanORB (remove the `data.forEach` loop to see the bug).

If the user passes a _String_ to the `groupBy` method, we create a custom `aggs` function for that key that treats those IDs as unique (and will not sum them up). For the logic needed when matching the "hover" IDs, this `aggs` method needs to cast the IDs it finds into Strings. It's not the _best_ solution, as the user will still have to pass a custom `aggs` function if the provide the `groupBy` method an accessor function, but that is usually an edge case (we typically pass _Strings_ to `groupBy`).