### PR TITLE
lightens default shapeConfig stroke darken logic

### DIFF
--- a/src/Viz.js
+++ b/src/Viz.js
@@ -227,7 +227,7 @@ export default class Viz extends BaseClass {
       opacity: constant(1),
       stroke: (d, i) => {
         const c = typeof this._shapeConfig.fill === "function" ? this._shapeConfig.fill(d, i) : this._shapeConfig.fill;
-        return color(c).darker();
+        return color(c).darker(0.25);
       },
       role: "presentation",
       strokeWidth: constant(0)


### PR DESCRIPTION
By default, visualization shapes use a `darker` version of their `fill` color for their stroke. The current darken method is fairly dramatic, and this will be very noticible when LinePlots use `colorScale` to color the lines (the lines appear much darker than what is shown in the scale itself).

Bumping the default value of the d3 `darker` function from `1` to `0.25` still provides enough of a slight darken so that the Lines are easily read on white backgrounds.