### PR TITLE
fixes timeline bug when changing dataset

### DIFF
--- a/src/_drawTimeline.js
+++ b/src/_drawTimeline.js
@@ -55,10 +55,15 @@ export default function(data = []) {
       .ticks(ticks.sort((a, b) => +a - +b))
       .width(this._width - (this._margin.left + this._margin.right + padding.left + padding.right));
 
+    const dataExtent = extent(data.map(this._time).map(date));
     if (!this._timelineSelection) {
-      this._timelineSelection = extent(data, this._time).map(date);
-      timeline.selection(this._timelineSelection);
+      this._timelineSelection = dataExtent;
     }
+    else {
+      if (this._timelineSelection[0] < dataExtent[0]) this._timelineSelection[0] = dataExtent[0];
+      if (this._timelineSelection[1] > dataExtent[1]) this._timelineSelection[1] = dataExtent[1];
+    }
+    timeline.selection(this._timelineSelection);
 
     const config = this._timelineConfig;
 


### PR DESCRIPTION
If you create a visualization with a certain set of data, and then change to a new dataset with less time resolution, the timeline brush will still try to maintain the old time extent. This PR analyzes for that data change, and adjusts the bounds of the timeline selection accordingly.

Code used for testing:

```js
const myData = [
    {
        "year": 2010,
        "year2": 2009,
        "color": "blue",
        "parent": "Parent 1",
        "id": "alpha",
        "value": 20,
        "value2": 40
    },
    {
        "year": 2010,
        "year2": 2010,
        "color": "blue",
        "parent": "Parent 2",
        "id": "beta",
        "value": 10,
        "value2": 5
    },
    {
        "year": 2011,
        "year2": 2011,
        "color": "red",
        "parent": "Parent 2",
        "id": "gamma",
        "value": 40,
        "value2": 45
    },
    {
        "year": 2011,
        "year2": 2012,
        "color": "red",
        "parent": "Parent 2",
        "id": "beta",
        "value": 20,
        "value2": 15
    },
    {
        "year": 2011,
        "year2": 2013,
        "color": "red",
        "parent": "Parent 2",
        "id": "delta",
        "value": 30,
        "value2": 5
    }
];

var viz = new d3plus.Viz()
  .data(myData)
  .time("year2")
  .timelineConfig({
    brushing: true
  })
  .timeFilter(d => d)
  .render();

setTimeout(() => {
  viz.time("year").render();
}, 2000);
```
