### PR TITLE
check if id is a number before stringify it

### DIFF
--- a/src/Viz.js
+++ b/src/Viz.js
@@ -348,7 +348,10 @@ export default class Viz extends BaseClass {
       : this._groupBy.length - 1;
 
     // Returns the current unique ID for a data point, coerced to a String.
-    this._id = (d, i) => typeof accessorFetch(this._groupBy[this._drawDepth], d, i) === "number" ? `${accessorFetch(this._groupBy[this._drawDepth], d, i)}` : accessorFetch(this._groupBy[this._drawDepth], d, i);
+    this._id = (d, i) => {
+      const groupByDrawDepth = accessorFetch(this._groupBy[this._drawDepth], d, i);
+      return typeof groupByDrawDepth === "number" ? `${groupByDrawDepth}` : groupByDrawDepth;
+    };
 
     // Returns an array of the current unique groupBy ID for a data point, coerced to Strings.
     this._ids = (d, i) => this._groupBy

--- a/src/Viz.js
+++ b/src/Viz.js
@@ -348,7 +348,7 @@ export default class Viz extends BaseClass {
       : this._groupBy.length - 1;
 
     // Returns the current unique ID for a data point, coerced to a String.
-    this._id = (d, i) => `${accessorFetch(this._groupBy[this._drawDepth], d, i)}`;
+    this._id = (d, i) => typeof accessorFetch(this._groupBy[this._drawDepth], d, i) === "number" ? `${accessorFetch(this._groupBy[this._drawDepth], d, i)}` : accessorFetch(this._groupBy[this._drawDepth], d, i);
 
     // Returns an array of the current unique groupBy ID for a data point, coerced to Strings.
     this._ids = (d, i) => this._groupBy


### PR DESCRIPTION
If you create a Network and assign data to each node by grouping them based on a numerical id, the network will crash because the `id` of each node becomes `"undefined"` (as a string). This happens because we are converting each id to a string in this line of code, where `undefined` becomes `"undefined"`:

```
this._id = (d, i) => `${accessorFetch(this._groupBy[this._drawDepth], d, i)}`;
```

This PR adds a check if the generated id is a `number`, and if so, it converts it to a string, otherwise it keeps the default value:

```
this._id = (d, i) => typeof accessorFetch(this._groupBy[this._drawDepth], d, i) === "number" ? 
  `${accessorFetch(this._groupBy[this._drawDepth], d, i)}` :
   accessorFetch(this._groupBy[this._drawDepth], d, i);
```

Code used for testing:

```
const viz = new d3plus.Network()
    .config({
      data: [
        {label: 0, value: 1},
        {label: 1, value: 1},
        {label: 2, value: 1},
        {label: 3, value: 1},
        {label: 4, value: 1},
        {label: 5, value: 1},
      ],
      groupBy: "label",
      nodes: [
        {id: 0},
        {id: 1},
        {id: 2},
        {id: 3},
        {id: 4},
        {id: 5}
      ],
      links: [
        {source: 0, target: 1, weight: 10},
        {source: 0, target: 2, weight: 10},
        {source: 3, target: 4, weight: 10},
        {source: 3, target: 5, weight: 5},
        {source: 5, target: 0, weight: 20},
        {source: 2, target: 1, weight: 12},
        {source: 4, target: 5, weight: 12}
      ]
    })
    .render()
```