### PR TITLE
add subtitle element

### DIFF
--- a/src/Viz.js
+++ b/src/Viz.js
@@ -29,6 +29,7 @@ import Message from "./Message.js";
 import drawBack from "./_drawBack.js";
 import drawColorScale from "./_drawColorScale.js";
 import {default as drawLegend, legendLabel} from "./_drawLegend.js";
+import drawSubtitle from "./_drawSubtitle.js";
 import drawTimeline from "./_drawTimeline.js";
 import drawTitle from "./_drawTitle.js";
 import drawTotal from "./_drawTotal.js";
@@ -249,6 +250,18 @@ export default class Viz extends BaseClass {
       strokeWidth: constant(0)
     };
     this._solo = [];
+
+    this._subtitleClass = new TextBox();
+    this._subtitleConfig = {
+      ariaHidden: true,
+      fontSize: 12,
+      padding: 5,
+      resize: false,
+      textAnchor: "middle"
+    };
+    this._subtitlePadding = defaultPadding;
+    this._subtitleClass = new TextBox();
+
     this._svgDesc = "";
     this._svgTitle = "";
 
@@ -462,6 +475,7 @@ export default class Viz extends BaseClass {
 
     drawBack.bind(this)();
     drawTitle.bind(this)(this._filteredData);
+    drawSubtitle.bind(this)(this._filteredData);
     drawTotal.bind(this)(this._filteredData);
     drawTimeline.bind(this)(this._filteredData);
 
@@ -1292,6 +1306,36 @@ function value(d) {
   */
   shapeConfig(_) {
     return arguments.length ? (this._shapeConfig = assign(this._shapeConfig, _), this) : this._shapeConfig;
+  }
+
+  /**
+      @memberof Viz
+      @desc If *value* is specified, sets the subtitle accessor to the specified function or string and returns the current class instance.
+      @param {Function|String} [*value*]
+      @chainable
+  */
+  subtitle(_) {
+    return arguments.length ? (this._subtitle = typeof _ === "function" ? _ : constant(_), this) : this._subtitle;
+  }
+    
+  /**
+      @memberof Viz
+      @desc If *value* is specified, sets the config method for the subtitle and returns the current class instance.
+      @param {Object} [*value*]
+      @chainable
+  */
+  subtitleConfig(_) {
+    return arguments.length ? (this._subtitleConfig = assign(this._subtitleConfig, _), this) : this._subtitleConfig;
+  }
+    
+  /**
+      @memberof Viz
+      @desc Tells the subtitle whether or not to use the internal padding defined by the visualization in it's positioning. For example, d3plus-plot will add padding on the left so that the subtitle appears centered above the x-axis. By default, this padding is only applied on screens larger than 600 pixels wide.
+      @param {Boolean|Function} [*value*]
+      @chainable
+  */
+  subtitlePadding(_) {
+    return arguments.length ? (this._subtitlePadding = typeof _ === "function" ? _ : constant(_), this) : this._subtitlePadding;
   }
 
   /**

--- a/src/Viz.js
+++ b/src/Viz.js
@@ -260,7 +260,6 @@ export default class Viz extends BaseClass {
       textAnchor: "middle"
     };
     this._subtitlePadding = defaultPadding;
-    this._subtitleClass = new TextBox();
 
     this._svgDesc = "";
     this._svgTitle = "";
@@ -280,7 +279,7 @@ export default class Viz extends BaseClass {
     this._titleClass = new TextBox();
     this._titleConfig = {
       ariaHidden: true,
-      fontSize: 12,
+      fontSize: 16,
       padding: 5,
       resize: false,
       textAnchor: "middle"

--- a/src/_drawSubtitle.js
+++ b/src/_drawSubtitle.js
@@ -1,0 +1,33 @@
+import {elem} from "d3plus-common";
+
+/**
+    @function _drawSubtitle
+    @desc Draws a subtitle if this._subtitle is defined.
+    @param {Array} [*data*] The currently filtered dataset.
+    @private
+*/
+export default function(data = []) {
+
+  const text = this._subtitle ? this._subtitle(data) : false;
+  const padding = this._subtitlePadding() ? this._padding : {top: 0, right: 0, bottom: 0, left: 0};
+
+  const transform = {transform: `translate(${this._margin.left + padding.left}, ${this._margin.top})`};
+
+  const group = elem("g.d3plus-viz-subtitle", {
+    enter: transform,
+    parent: this._select,
+    duration: this._duration,
+    update: transform
+  }).node();
+
+  this._subtitleClass
+    .data(text ? [{text}] : [])
+    .locale(this._locale)
+    .select(group)
+    .width(this._width - (this._margin.left + this._margin.right + padding.left + padding.right))
+    .config(this._subtitleConfig)
+    .render();
+
+  this._margin.top += text ? group.getBBox().height + this._subtitleConfig.padding * 2 : 0;
+
+}


### PR DESCRIPTION
In some cases, it is necessary to add a second line of text as a visualization subtitle. This allows indicating actions or restrictions within the same container. 
This PR adds the `subtitle` property, along with `subtitleConfig` and `subtitlePadding`, to make the task easier. 
It allows the user to add a subtitle to the visualization container (below the title and above the total) and style it according to their preferences (related to #177).

```
var viz = new d3plus.Viz()
  .data([
    {
      id: 1,
      value: 1
    }
  ])
  .title("Title")
  .subtitle("[I'm a big blue subtitle]")
  .subtitleConfig({
       fontColor: "blue",
       fontSize: 30,
       fontWeight: 600,
  })
  .total(() => "200")
  .totalFormat((total) => `Total value: $${total}`)
  .render();

```
<img width="1904" alt="image" src="https://github.com/d3plus/d3plus-viz/assets/39899484/9875ea7c-4b18-4745-a7f9-c6ada82565b4">

